### PR TITLE
External display and time.sleep patches.

### DIFF
--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -136,10 +136,16 @@ class Vec2D(tuple):
 class turtle(object):
     """A Turtle that can be given commands to draw."""
 
-    def __init__(self, display=board.DISPLAY):
+    def __init__(self, display=None):
+        if display:
+            self._display = display
+        else:
+            try:
+                self._display = board.DISPLAY
+            except AttributeError:
+                raise RuntimeError("No display available. One must be provided.")
         self._logger = logging.getLogger("Turtle")
         self._logger.setLevel(logging.INFO)
-        self._display = display
         self._w = self._display.width
         self._h = self._display.height
         self._x = self._w // 2
@@ -193,9 +199,7 @@ class turtle(object):
         self.pencolor(Color.WHITE)
 
         self._display.show(self._splash)
-        self._display.refresh_soon()
         gc.collect()
-        self._display.wait_for_frame()
 
     def _drawturtle(self):
         self._turtle_sprite.x = int(self._x - 4)
@@ -298,7 +302,6 @@ class turtle(object):
                 self._x = y0
                 self._y = x0
                 self._drawturtle()
-                time.sleep(0.003)
             else:
                 try:
                     self._plot(int(x0), int(y0), self._pencolor)
@@ -307,7 +310,6 @@ class turtle(object):
                 self._x = x0
                 self._y = y0
                 self._drawturtle()
-                time.sleep(0.003)
             err -= dy
             if err < 0:
                 y0 += ystep
@@ -804,10 +806,8 @@ class turtle(object):
                 self._fg_bitmap[w, h] = 0
         for i, c in enumerate(Color.colors):
             self._fg_palette[i + 1] = c ^ 0xFFFFFF
-        self._display.refresh_soon()
         for i, c in enumerate(Color.colors):
             self._fg_palette[i + 1] = c
-        self._display.refresh_soon()
         time.sleep(0.1)
 
     def write(self, arg, move=False, align="left", font=("Arial", 8, "normal")):


### PR DESCRIPTION
Fixes #10 and #11. Also removed deprecated `displayio` calls.

**Please let me know if these test are _not_ adequate for #10.**

### Built In Display Test
PyPortal w/ CP 4.1.0
```python
import board
from adafruit_turtle import Color, turtle

turtle = turtle(board.DISPLAY)
benzsize = min(board.DISPLAY.width, board.DISPLAY.height) * 0.5

print("Turtle time! Lets draw a rainbow benzene")

colors = (Color.RED, Color.ORANGE, Color.YELLOW, Color.GREEN, Color.BLUE, Color.PURPLE)

turtle.pendown()
start = turtle.pos()

for x in range(benzsize):
    turtle.pencolor(colors[x%6])
    turtle.forward(x)
    turtle.left(59)

while True:
    pass
```
![pp](https://user-images.githubusercontent.com/8755041/66860501-29391e80-ef42-11e9-9936-c309ea9a0950.jpg)

### External Display Test
CPB w/ CP 5.0.0 alpha 4
```python
import board
import busio
import displayio
from adafruit_st7789 import ST7789
from adafruit_turtle import Color, turtle

displayio.release_displays()

spi = busio.SPI(board.SCL, MOSI=board.SDA)
tft_cs = board.RX
tft_dc = board.TX
tft_backlight = board.A3

display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)

display = ST7789(display_bus, width=240, height=240, rowstart=80,
                 backlight_pin=tft_backlight, rotation=180)

turtle = turtle(display)
benzsize = min(display.width, display.height) * 0.5

print("Turtle time! Lets draw a rainbow benzene")

colors = (Color.RED, Color.ORANGE, Color.YELLOW, Color.GREEN, Color.BLUE, Color.PURPLE)

turtle.pendown()
start = turtle.pos()

for x in range(benzsize):
    turtle.pencolor(colors[x%6])
    turtle.forward(x)
    turtle.left(59)

while True:
    pass
```
![cpb_gizmo](https://user-images.githubusercontent.com/8755041/66860554-47068380-ef42-11e9-934c-77a3def80c36.jpg)
