### PR TITLE
patch for Vec2D.__repr__

### DIFF
--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -130,8 +130,7 @@ class Vec2D(tuple):
         return (self[0], self[1])
 
     def __repr__(self):
-        return "(%.2f,%.2f)" % self
-
+        return "({:.2f},{:.2f})".format(self[0], self[1])
 
 class turtle(object):
     """A Turtle that can be given commands to draw."""


### PR DESCRIPTION
Possible fix for #14 .

Focusing on just the `Vec2D` class, here's a more direct example of the issue:
```python
Adafruit CircuitPython 4.1.0 on 2019-08-02; Adafruit PyPortal with samd51j20
>>> from adafruit_turtle import Vec2D
>>> foo = Vec2D(1,2)
>>> foo
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/adafruit_turtle.py", line 133, in __repr__
TypeError: can't convert Vec2D to float
>>> 
```

With this patch:
```python
Adafruit CircuitPython 4.1.0 on 2019-08-02; Adafruit PyPortal with samd51j20
>>> from adafruit_turtle import Vec2D
>>> foo = Vec2D(1,2)
>>> foo
(1.00,2.00)
>>> eval(repr(foo))
(1.0, 2.0)
>>> 
```

Also ran **all** the examples to make sure they still work.