### PR TITLE
fix heading angle table in docs

### DIFF
--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -421,11 +421,14 @@ class turtle:
         """Set the orientation of the turtle to to_angle. Here are some common
         directions in degrees:
 
-        standard mode | logo mode
-        0 - east | 0 - north
-        90 - north | 90 - east
-        180 - west | 180 - south
-        270 - south | 270 - west
+        =====  =============  ==========
+        angle  standard mode  logo mode
+        =====  =============  ==========
+        0      east           north
+        90     north          east
+        180    west           south
+        270    south          west
+        =====  =============  ==========
 
         :param to_angle: the new turtle heading
 


### PR DESCRIPTION
This fixes the table in the docs that show which angles map to which directions based on whether the turtle is in standard or logo mode.

The current docs look like this: 
![image](https://user-images.githubusercontent.com/2406189/132103192-1456ffc7-bc6d-42d8-bdb2-e39e57f1343f.png)

After this change it looks like this:
![image](https://user-images.githubusercontent.com/2406189/132103179-ccd56388-4530-46f4-b648-9c282b8739f0.png)
