### PR TITLE
Remove cp 6 fallback

### DIFF
--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -641,12 +641,6 @@ class turtle:
         turtle position. Return a stamp_id for that stamp, which can be used to
         delete it by calling clearstamp(stamp_id).
         """
-        # The restriction on max_size in displayio.Group has been removed.
-        # For now, leave this with a limit of 6 so as not to break any
-        # deployed code.
-        if len(self._fg_addon_group) >= 6:
-            print("Addon group full")
-            return -1
         s_id = len(self._stamps)
         if self._turtle_pic is None:
             # easy.
@@ -660,11 +654,7 @@ class turtle:
             # odb bitmap
             new_stamp = displayio.TileGrid(
                 self._turtle_odb,
-                pixel_shader=getattr(
-                    self._turtle_odb, "pixel_shader", displayio.ColorConverter()
-                ),
-                # TODO: Once CP6 is no longer supported, replace the above line with below
-                # pixel_shader=self._turtle_odb.pixel_shader,
+                pixel_shader=self._turtle_odb.pixel_shader,
                 x=int(self._x - self._turtle_odb.width // 2),
                 y=int(self._y - self._turtle_odb.height // 2),
             )
@@ -974,13 +964,11 @@ class turtle:
                 self._bg_pic = None
                 self._bg_pic_filename = ""
         else:
-            with open(picname, "rb") as self._bg_pic:
-                odb = displayio.OnDiskBitmap(self._bg_pic)
+            odb = displayio.OnDiskBitmap(picname)
+
             self._odb_tilegrid = displayio.TileGrid(
                 odb,
-                pixel_shader=getattr(odb, "pixel_shader", displayio.ColorConverter()),
-                # TODO: Once CP6 is no longer supported, replace the above line with below
-                # pixel_shader=odb.pixel_shader,
+                pixel_shader=odb.pixel_shader,
             )
             self._bg_addon_group.append(self._odb_tilegrid)
             self._bg_pic_filename = picname
@@ -1103,11 +1091,7 @@ class turtle:
             self._turtle_pic = True
             self._turtle_alt_sprite = displayio.TileGrid(
                 self._turtle_odb,
-                pixel_shader=getattr(
-                    self._turtle_odb, "pixel_shader", displayio.ColorConverter()
-                ),
-                # TODO: Once CP6 is no longer supported, replace the above line with below
-                # pixel_shader=self._turtle_odb.pixel_shader,
+                pixel_shader=self._turtle_odb.pixel_shader,
             )
 
             if self._turtle_group:

--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -691,8 +691,7 @@ class turtle:
                 if isinstance(self._stamps[stampid], tuple):
                     self._fg_addon_group.remove(self._stamps[stampid][0])
                     self._turtle_odb_use -= 1
-                    if self._turtle_odb_use == 0:
-                        self._stamps[stampid][1].close()
+
                 else:
                     self._fg_addon_group.remove(self._stamps[stampid])
                 self._stamps[stampid] = None
@@ -960,7 +959,6 @@ class turtle:
             if self._bg_pic is not None:
                 self._bg_addon_group.remove(self._odb_tilegrid)
                 self._odb_tilegrid = None
-                self._bg_pic.close()
                 self._bg_pic = None
                 self._bg_pic_filename = ""
         else:
@@ -1057,8 +1055,6 @@ class turtle:
                 self._turtle_odb_use -= 1
                 self._turtle_odb = None
             if self._turtle_odb_file is not None:
-                if self._turtle_odb_use == 0:
-                    self._turtle_odb_file.close()
                 self._turtle_odb_file = None
             self._turtle_pic = None
             self._drawturtle()
@@ -1071,17 +1067,13 @@ class turtle:
                 self._turtle_alt_sprite = None
                 self._turtle_odb = None
                 if not isinstance(self._turtle_pic, tuple):
-                    self._turtle_odb_file.close()
                     self._turtle_odb_file = None
                     self._turtle_odb_use -= 1
                 self._turtle_pic = None
-            self._turtle_odb_file = open(  # pylint: disable=consider-using-with
-                source, "rb"
-            )
+
             try:
-                self._turtle_odb = displayio.OnDiskBitmap(self._turtle_odb_file)
+                self._turtle_odb = displayio.OnDiskBitmap(source)
             except:
-                self._turtle_odb_file.close()
                 self._turtle_odb_file = None
                 self._turtle_pic = None
                 if visible:
@@ -1103,8 +1095,6 @@ class turtle:
             if self._turtle_pic is not None:
                 if self._turtle_odb_file is not None:
                     self._turtle_odb_use -= 1
-                    if self._turtle_odb_use == 0:
-                        self._turtle_odb_file.close()
             self._turtle_pic = dimensions
             self._turtle_alt_sprite = source
             if self._turtle_group:


### PR DESCRIPTION
This changes removes all pixel_shader CP 6 compatibility code. So moving forward the library is compatible with CP 7+ only.

I also removed the now-artificial limit on number of things in the addon_group. 

And changed the remaining instances of files being opened before passed to OnDiskBitmap() constructor to instead pass the filenames and let the file be managed internally.

Tested successfully with modified version of `turtle_bgpic_changeturtle.py` script on PyPortal 7.2.0 rc0 as well as a few of the other fractal examples.