### PR TITLE
CPython compatibility fix

### DIFF
--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -35,7 +35,7 @@ import displayio
 
 try:
     import board
-except:
+except NotImplementedError:
     print("[adafruit-turtle.py]: Couldn't import board module.")
 
 __version__ = "0.0.0+auto.0"
@@ -101,6 +101,9 @@ class Vec2D:
     #     a.rotate(angle) rotation
     def __new__(cls, x, y):
         return (x, y)
+
+    def __getitem__(self, index):
+        return getattr(self, index)
 
     def __add__(self, other):
         return Vec2D(self[0] + other[0], self[1] + other[1])

--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -30,8 +30,11 @@ Implementation Notes
 import gc
 import math
 import time
-import board
 import displayio
+try:
+    import board
+except:
+    print("[adafruit-turtle.py]: Couldn't import board module.")
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_turtle.git"
@@ -80,7 +83,7 @@ class Color:
         pass
 
 
-class Vec2D(tuple):
+class Vec2D():
     """A 2 dimensional vector class, used as a helper class
     for implementing turtle graphics.
     May be useful for turtle graphics programs also.
@@ -94,8 +97,8 @@ class Vec2D(tuple):
     #     k*a and a*k multiplication with scalar
     #     |a| absolute value of a
     #     a.rotate(angle) rotation
-    def __init__(self, x, y):
-        super().__init__((x, y))
+    def __new__(cls, x, y):
+        return (x, y)
 
     def __add__(self, other):
         return Vec2D(self[0] + other[0], self[1] + other[1])

--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2006-2010 Gregor Lingl for Adafruit Industries
 # SPDX-FileCopyrightText: 2019 LadyAda for Adafruit Industries
 # SPDX-FileCopyrightText: 2021 Dave Astels for Adafruit Industries
+# SPDX-FileCopyrightText: 2022 Carsten Thue-Bludworth for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 

--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -31,6 +31,7 @@ import gc
 import math
 import time
 import displayio
+
 try:
     import board
 except:
@@ -83,7 +84,7 @@ class Color:
         pass
 
 
-class Vec2D():
+class Vec2D:
     """A 2 dimensional vector class, used as a helper class
     for implementing turtle graphics.
     May be useful for turtle graphics programs also.

--- a/adafruit_turtle.py
+++ b/adafruit_turtle.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2006-2010 Gregor Lingl for Adafruit Industries
 # SPDX-FileCopyrightText: 2019 LadyAda for Adafruit Industries
 # SPDX-FileCopyrightText: 2021 Dave Astels for Adafruit Industries
-# SPDX-FileCopyrightText: 2022 Carsten Thue-Bludworth for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
For this PR, I changed two things.

1. I added a conditional import for the `board` module, so that on non-CircuitPython devices (i.e. generic computers), this script will library will still work.
2. I removed the `tuple` subclass from the `Vec2D` class, as the constructor/initializer was incompatible with CPython. Instead, I use the `__new__` constructor and just explicitly return a `tuple` instead of calling the `super` constructor.

Now this library works as-is for devices running `adafruit-blinka`, such as a Raspberry Pi with a PiTFT display, or generic PCs using something like `PygameDisplay`.