### PR TITLE
Fix pylint errors

### DIFF
--- a/examples/turtle_hilbert.py
+++ b/examples/turtle_hilbert.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+# pylint: disable=unnecessary-lambda-assignment
+
 import board
 from adafruit_turtle import turtle
 

--- a/examples/turtle_koch.py
+++ b/examples/turtle_koch.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+# pylint: disable=unnecessary-lambda-assignment
+
 import board
 from adafruit_turtle import turtle
 

--- a/examples/turtle_overlayed_koch.py
+++ b/examples/turtle_overlayed_koch.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+# pylint: disable=unnecessary-lambda-assignment
+
 import board
 from adafruit_turtle import turtle, Color
 


### PR DESCRIPTION
I struggled with whether to actually refactor this one, but I think the use of lambda makes the examples more readable as well as shows off exactly how turtle works better.

Fixes the following `pylint` errors:

```

************* Module turtle_overlayed_koch
Error: examples/turtle_overlayed_koch.py:12:15: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: examples/turtle_overlayed_koch.py:23:15: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
************* Module turtle_koch
Error: examples/turtle_koch.py:10:15: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: examples/turtle_koch.py:30:11: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
************* Module turtle_hilbert
Error: examples/turtle_hilbert.py:10:12: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: examples/turtle_hilbert.py:11:12: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: examples/turtle_hilbert.py:12:15: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: examples/turtle_hilbert.py:13:16: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
Error: examples/turtle_hilbert.py:14:18: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
```
